### PR TITLE
Allow falsy json compatible secrets values

### DIFF
--- a/lib/get-value.js
+++ b/lib/get-value.js
@@ -37,7 +37,8 @@ function getValue(key, env, secrets = {}, required = {}) {
   // if the value doesn't start with @ (it's not a secret) return it
   if (`${value}`.indexOf('@') !== 0) return value
   // try get the secret secret or return the value
-  return getSecretValue(value, secrets) || value
+  const secretValue = getSecretValue(value, secrets)
+  return secretValue !== undefined ? secretValue : value
 
 }
 


### PR DESCRIPTION
This PR brings ability to define empty secret values (like empty strings or null).

It's can be useful for empty passwords in local dev environment for example.

For now, if secret values with name `"@db-password"` equal `""` (empty string) `process.env.DB_PASSWORD` variable will be equal `@db-password`.

Is it make sense, what do you think?