### PR TITLE
Correctly handle secrets

### DIFF
--- a/lib/get-value.js
+++ b/lib/get-value.js
@@ -8,7 +8,7 @@
  */
 function getValue(key, env, secrets = {}, required = {}) {
   let value
-  
+
   if (required.hasOwnProperty(key)) {
     // Get required value
     value = required[key]
@@ -28,7 +28,7 @@ function getValue(key, env, secrets = {}, required = {}) {
   // Otherwise, hand back the secret. This will
   // intentionally return `undefined` if the secret
   // is not defined so that the
-  // developers knows that the secret is not defined.
+  // developers knows it is not defined.
   return secrets[key]
 }
 

--- a/lib/get-value.js
+++ b/lib/get-value.js
@@ -6,7 +6,7 @@
  * @param  {String} key      The environment key name
  * @return {String}          The environment value
  */
-function getValue(key, env, secrets = {}, required = {}) {
+module.exports = getValue(key, env, secrets = {}, required = {}) => {
   let value
 
   if (required.hasOwnProperty(key)) {
@@ -31,5 +31,3 @@ function getValue(key, env, secrets = {}, required = {}) {
   // developers knows it is not defined.
   return secrets[key]
 }
-
-module.exports = getValue

--- a/lib/get-value.js
+++ b/lib/get-value.js
@@ -1,19 +1,4 @@
 /**
- * Get the secret value
- * @param  {String} key          The secret key
- * @param  {Object} [secrets={}] The secrets map
- * @return {String}              The secret value
- */
-function getSecretValue(key, secrets = {}) {
-  // check if the value is in the secret map
-  const value = secrets[key]
-  // if is defined return the secret
-  if (value !== undefined) return value
-  // try get the secret value without @ from the map
-  return secrets[key.slice(1)]
-}
-
-/**
  * Get the value of a environment variable or secret
  * @param  {Object} env      Map of environment variables
  * @param  {Object} secrets  Map of secrets
@@ -23,22 +8,28 @@ function getSecretValue(key, secrets = {}) {
  */
 function getValue(key, env, secrets = {}, required = {}) {
   let value
+  
   if (required.hasOwnProperty(key)) {
-    // get required value
+    // Get required value
     value = required[key]
   } else if (env.hasOwnProperty(key)){
-    // get environment value
+    // Get environment value
     value = env[key]
   } else {
-    // if the value is not defined throw an error
+    // If the value is not defined throw an error
     throw new ReferenceError(`The environment variable ${key} is required.`)
   }
 
-  // if the value doesn't start with @ (it's not a secret) return it
-  if (`${value}`.indexOf('@') !== 0) return value
-  // try get the secret secret or return the value
-  return getSecretValue(value, secrets) || value
+  // If the value doesn't start with @ (it's not a secret) return it
+  if (`${value}`.indexOf('@') !== 0) {
+    return value
+  }
 
+  // Otherwise, hand back the secret. This will
+  // intentionally return `undefined` if the secret
+  // is not defined so that the
+  // developers knows that the secret is not defined.
+  return secrets[key]
 }
 
 module.exports = getValue

--- a/lib/get-value.js
+++ b/lib/get-value.js
@@ -6,7 +6,7 @@
  * @param  {String} key      The environment key name
  * @return {String}          The environment value
  */
-module.exports = getValue(key, env, secrets = {}, required = {}) => {
+module.exports = (key, env, secrets = {}, required = {}) => {
   let value
 
   if (required.hasOwnProperty(key)) {


### PR DESCRIPTION
After this PR:

- Only secrets starting with `@` are allowed
- Secrets can now have falsy values
- We return `undefined` instead of the secret name for secrets that are not defined

This closes #6 and fixes #3.