### PR TITLE
Add ENV variable for now-secrets.json file

### DIFF
--- a/lib/load-secrets.js
+++ b/lib/load-secrets.js
@@ -6,7 +6,7 @@ const isModuleMissing = require('./module.js')
  * @return {Object} Map of secrets
  */
 function loadSecrets() {
-  const SECRET_PATH = resolve('./now-secrets.json')
+  const SECRET_PATH = resolve(process.env.NOW_SECRETS_CONFIG || './now-secrets.json')
 
   try {
     return require(SECRET_PATH)


### PR DESCRIPTION
To be consistent with `load_now_json` that can use a path coming from `process.env`, I added the same thing in `load_secrets.js`.

It allows a better flexibility (in my case for a monorepo)