### PR TITLE
Add support for build variables

### DIFF
--- a/lib/load-now-json.js
+++ b/lib/load-now-json.js
@@ -18,6 +18,10 @@ function loadNowJSON(secrets = {}, required = {}) {
       applyEnv(nowFile.env, secrets, required)
     }
 
+    if (nowFile.build && nowFile.build.env) {
+      applyEnv(nowFile.build.env, secrets, required)
+    }
+
     return true
   } catch (error) {
     if (isModuleMissing(error)) {


### PR DESCRIPTION
Hi Zeit team, loving what you guys are working on.

The current version of now-env replaces now.json's `env` key but leaves `build.env` untouched. This PR simply applies the same replacement to build variables.

Related to: https://github.com/zeit/now-env/issues/22