### PR TITLE
Remove now.json and Update README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
 # now-env
 
-_This package has now been deprecated with the [release of `now dev`](https://zeit.co/blog/now-dev). We recommend setting environment variables either by [using a `.env` file](https://zeit.co/docs/v2/development/environment-variables/#using-a-.env-file), or inside a [`now.json` file](https://zeit.co/docs/v2/development/environment-variables/#using-now.json). For more information you should read the [full documentation](https://zeit.co/docs/v2/development/environment-variables)._
+_This package has now been deprecated with the [release of `now dev`](https://zeit.co/blog/now-dev). We recommend setting environment variables by [using a `.env` file](https://zeit.co/docs/v2/serverless-functions/env-and-secrets/#providing-environment-variables). For more information you should read the [full documentation](https://zeit.co/docs/v2/serverless-functions/env-and-secrets/#providing-environment-variables)._


### PR DESCRIPTION
This PR removes the `now.json` reference from the README and updates links.